### PR TITLE
Implement the `curry` function, useful for partial application. #feat

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -287,7 +287,7 @@ impl fmt::Debug for Expr {
             Expr::Comment(s, _) => format!("Comment({s})"),
             Expr::TextSeparator => "<TEXT-SEPARATOR>".to_owned(),
             Expr::Bool(b) => format!("Bool({b})"),
-            Expr::Symbol(s) => format!("Symbol({s})"),
+            Expr::Symbol(s) => format!("'{s}"), // "Symbol(s)"
             Expr::KeySymbol(s) => format!("KeySymbol({s})"),
             Expr::Type(s) => format!("Type({s})"),
             Expr::Char(c) => format!("Char({c})"),
@@ -329,7 +329,7 @@ impl fmt::Debug for Expr {
             // #todo uncomment only for debugging purposes!
             // Expr::Annotated(expr, ann) => format!("ANN({expr:?}, {ann:?})"),
             // #insight intentionally ignore annotations in formatting the formatting.
-            Expr::Annotated(expr, _ann) => format!("#({expr:?})"), // #skip annotations.
+            Expr::Annotated(expr, _ann) => format!("#({expr:?})"), // "Ann({expr:?})"
             Expr::Annotation(ann) => format!("Annotation(#{ann})"),
             Expr::Module(module) => format!("Module({})", module.stem),
         };
@@ -427,11 +427,13 @@ impl fmt::Display for Expr {
                         format!("{start}..{end}|{step}")
                     }
                 }
-                Expr::Func(..) => "#<func>".to_owned(),
-                Expr::Macro(..) => "#<func>".to_owned(),
-                Expr::ForeignFunc(..) => "#<foreign-func>".to_owned(),
-                Expr::ForeignStruct(..) => "#<foreign-struct>".to_owned(),
-                Expr::ForeignStructMut(..) => "#<foreign-struct-mut>".to_owned(),
+                // Expr::Func(..) => "#<func>".to_owned(),
+                Expr::Func(params, ..) => format!("<FUNC {:?}>", params),
+                // Expr::Func(params, body, ..) => format!("<FUNC {:?} -> {:?}>", params, body), // #hint Useful for debugging.
+                Expr::Macro(..) => "<MACRO>".to_owned(),
+                Expr::ForeignFunc(..) => "<FOREIGN-FUNC>>".to_owned(),
+                Expr::ForeignStruct(..) => "<FOREIGN-STRUCT>".to_owned(),
+                Expr::ForeignStructMut(..) => "<FOREIGN-STRUCT-MUT>".to_owned(),
                 // #insight intentionally pass through the formatting.
                 Expr::Annotated(expr, _) => format!("{expr}"),
                 Expr::Annotation(ann) => format!("#{ann}"),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -309,7 +309,7 @@ impl fmt::Debug for Expr {
                 )
             }
             Expr::Buffer(size, v) => format!("Buffer({size}, {v:?})"),
-            Expr::Array(v) => format!("Array({v:?})"),
+            Expr::Array(v) => format!("Array({:?})", v.read().expect("poisoned lock")),
             Expr::Map(d) => format!("Map({d:?})"),
             Expr::Set(d) => format!("Set({d:?})"),
             Expr::IntRange(start, end, step) => format!("IntRange({start},{end},{step})"),
@@ -329,7 +329,7 @@ impl fmt::Debug for Expr {
             // #todo uncomment only for debugging purposes!
             // Expr::Annotated(expr, ann) => format!("ANN({expr:?}, {ann:?})"),
             // #insight intentionally ignore annotations in formatting the formatting.
-            Expr::Annotated(expr, _ann) => format!("Ann({expr:?})"), // #skip annotations.
+            Expr::Annotated(expr, _ann) => format!("#({expr:?})"), // #skip annotations.
             Expr::Annotation(ann) => format!("Annotation(#{ann})"),
             Expr::Module(module) => format!("Module({})", module.stem),
         };

--- a/src/library/lang.rs
+++ b/src/library/lang.rs
@@ -15,6 +15,7 @@ use crate::{
         util::{canonicalize_module_path, eval_file},
     },
     expr::{annotate, expr_clone, Expr},
+    scope::Scope,
     util::{
         args::{unpack_arg, unpack_map_arg, unpack_stringable_arg, unpack_symbolic_arg},
         module_util::require_module,
@@ -227,6 +228,65 @@ pub fn eval_string(args: &[Expr], context: &mut Context) -> Result<Expr, Error> 
     }
 }
 
+// #todo NOT WORKING!
+fn curry(
+    params: &[Expr],
+    body: &[Expr],
+    func_scope: &Arc<Scope>,
+    filename: String,
+) -> Option<Expr> {
+    params.first().map(|param| {
+        let rest_params = &params[1..];
+        if rest_params.is_empty() {
+            Expr::Func(
+                vec![param.clone()],
+                body.to_owned(),
+                func_scope.clone(),
+                filename.clone(),
+            )
+        } else {
+            // (Func [a1] (Func [a2] (Func [a3] body)))
+            let curried_body = Expr::List(vec![Expr::Type("Func".to_owned()), Expr::array(vec![])]);
+            Expr::Func(
+                rest_params.to_owned(),
+                vec![curried_body],
+                func_scope.clone(),
+                filename.clone(),
+            )
+        }
+    })
+}
+
+// #todo NOT WORKING!
+// #todo #insight Cannot curry a function with zero parameters, just return the function unchanged!
+pub fn func_curry(args: &[Expr], _context: &mut Context) -> Result<Expr, Error> {
+    // (let add1 (Func [x y] (+ x y 1)))
+    // (let curried-add1 (curry add1))
+
+    let Some(func) = args.first() else {
+        return Err(Error::invalid_arguments("expected `func` argument", None));
+    };
+
+    let Expr::Func(params, body, func_scope, filename) = func.unpack() else {
+        return Err(Error::invalid_arguments(
+            "`func` argument should be a Func",
+            None,
+        ));
+    };
+
+    dbg!(&body);
+
+    let curried_func = curry(params, body, func_scope, filename.clone()).unwrap_or(func.clone());
+
+    // #todo Also re-apply annotations.
+
+    if let Expr::Func(_, body, ..) = &curried_func {
+        dbg!(&body);
+    }
+
+    Ok(curried_func)
+}
+
 // #todo consider link_foreign_dyn_lib (and unlink_...)
 // #todo introduce unlink_foreign_dyn_lib for completeness.
 // #todo find a better name, consider `use` or `load` instead of `install`.
@@ -326,6 +386,9 @@ pub fn setup_lib_lang(context: &mut Context) {
     );
 
     module.insert("load-file", Expr::ForeignFunc(Arc::new(load_file)));
+
+    // #todo Move to a namespace, e.g. `/func`.
+    module.insert("curry", Expr::ForeignFunc(Arc::new(func_curry)));
 
     module.insert(
         "link-foreign-dyn-lib",

--- a/src/library/lang.rs
+++ b/src/library/lang.rs
@@ -246,6 +246,16 @@ fn curry(params: &[Expr], body: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
     })
 }
 
+// #todo Also support passing argument, implements partial application:
+//
+// (let greet (Func [msg name] "${msg} ${name}"))
+// (let hello (curry greet "Hello"))
+// (let hello "George") ; => "Hello George"
+//
+// Currently you can do:
+// (let hello ((curry greet) "Hello"))
+// (let hello "George") ; => "Hello George"
+//
 // #todo Convert to macro, evaluate at compile/static time.
 // #todo #insight Cannot curry a function with zero parameters, just return the function unchanged!
 // (let add1 (Func [x y] (+ x y 1)))


### PR DESCRIPTION
In the future we will introduce a more sophisticated method for partial application.